### PR TITLE
feat: allow FE to request tanzaku count via /client limit

### DIFF
--- a/src/routes/tanzaku.ts
+++ b/src/routes/tanzaku.ts
@@ -47,7 +47,7 @@ tanzaku.get("/client", async (c) => {
   const parsedLimit = Number.parseInt(limitQuery ?? "", 10);
   const limit =
     Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : 10;
-  const result = await service.getTwentyTanzaku(limit);
+  const result = await service.getClientTanzaku(limit);
 
   return c.json(result);
 });

--- a/src/routes/tanzaku.ts
+++ b/src/routes/tanzaku.ts
@@ -45,7 +45,8 @@ tanzaku.get("/client", async (c) => {
   const service = new TanzakuService(c.env.DB);
   const limitQuery = c.req.query("limit");
   const parsedLimit = Number.parseInt(limitQuery ?? "", 10);
-  const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : 10;
+  const limit =
+    Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : 10;
   const result = await service.getTwentyTanzaku(limit);
 
   return c.json(result);

--- a/src/routes/tanzaku.ts
+++ b/src/routes/tanzaku.ts
@@ -43,7 +43,10 @@ tanzaku.get("/check/:id", async (c) => {
 
 tanzaku.get("/client", async (c) => {
   const service = new TanzakuService(c.env.DB);
-  const result = await service.getTwentyTanzaku();
+  const limitQuery = c.req.query("limit");
+  const parsedLimit = Number.parseInt(limitQuery ?? "", 10);
+  const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : 10;
+  const result = await service.getTwentyTanzaku(limit);
 
   return c.json(result);
 });

--- a/src/services/tanzaku.service.ts
+++ b/src/services/tanzaku.service.ts
@@ -89,7 +89,9 @@ export class TanzakuService {
     });
   }
 
-  async getTwentyTanzaku() {
+  async getTwentyTanzaku(limit = 10) {
+    const safeLimit = Math.min(30, Math.max(1, Math.floor(limit)));
+
     const checkexistance = await this.prisma.tanzaku.findMany({
       take: 1,
       where: {
@@ -108,7 +110,7 @@ export class TanzakuService {
     }
 
     const result = await this.prisma.tanzaku.findMany({
-      take: 10,
+      take: safeLimit,
       orderBy: {
         createdAt: "desc"
       },

--- a/src/services/tanzaku.service.ts
+++ b/src/services/tanzaku.service.ts
@@ -89,7 +89,7 @@ export class TanzakuService {
     });
   }
 
-  async getTwentyTanzaku(limit = 10) {
+  async getClientTanzaku(limit = 10) {
     const safeLimit = Math.min(30, Math.max(1, Math.floor(limit)));
 
     const checkexistance = await this.prisma.tanzaku.findMany({


### PR DESCRIPTION
## Summary
- add limit query support to GET /tanzaku/client
- pass parsed/sanitized limit from route to service
- make service take dynamic count (1..30) instead of fixed 10

## Why
FE sakura mode needs to request more cards (e.g. 14) while keeping default behavior for existing callers.

## Notes
- default remains 10 when limit is missing/invalid
- upper bound is clamped to 30 for safety
