### PR TITLE
fix: 短冊検証モデルを Llama 4 Scout に差し替え

### DIFF
--- a/src/services/tanzaku.service.ts
+++ b/src/services/tanzaku.service.ts
@@ -115,13 +115,14 @@ export class TanzakuService {
           `${data.content}${data.userName}`
         );
       } catch (error) {
-        // 検証が失敗しても投稿自体は通す（イベント運用を止めない）。
-        // 失敗時は表示側(0)に倒し、問題があれば管理画面で対応する。
+        // 検証が失敗しても投稿自体は通す（500 で止めない）。ただし安全側に倒し、
+        // 未検証のコンテンツがウォールに出ないよう非表示(1)で保存する。
+        // 正当な投稿が巻き込まれた場合は管理画面で表示(0)に直せる。
         console.error(
-          "Validation failed; saving tanzaku as visible (0):",
+          "Validation failed; saving tanzaku as hidden (1):",
           error
         );
-        validationResult = VALIDATION_OK;
+        validationResult = VALIDATION_NG;
       }
     }
 

--- a/src/services/tanzaku.service.ts
+++ b/src/services/tanzaku.service.ts
@@ -45,12 +45,19 @@ const extractValidationResult = (raw: unknown): number | null => {
     // フォールバックに進む
   }
 
-  // 2) 文中に埋め込まれた "result": 0/1 を拾う（前後に説明文があっても可）
-  const match = responseField.match(/result["']?\s*[:=]\s*([01])/i);
-  if (match) {
-    return Number(match[1]);
+  // 2) 文中に埋め込まれた "result": 0/1 を拾う（前後に説明文があっても可）。
+  //    モデルが暴走して複数の result を羅列することがあるため、全件を集めて
+  //    値が一意のときだけ採用する。0 と 1 が混在＝曖昧なら null を返して
+  //    安全側（呼び出し元で非表示=1）に倒す。最初の一致を盲信しない。
+  const matches = [
+    ...responseField.matchAll(/result["']?\s*[:=]\s*([01])/gi)
+  ];
+  const distinct = new Set(matches.map((m) => Number(m[1])));
+  if (distinct.size === 1) {
+    return [...distinct][0];
   }
 
+  // 一致なし、または 0/1 が混在して判別不能
   return null;
 };
 

--- a/src/services/tanzaku.service.ts
+++ b/src/services/tanzaku.service.ts
@@ -1,54 +1,66 @@
 import { PrismaD1 } from "@prisma/adapter-d1";
 import { PrismaClient } from "../generated/prisma";
 
-interface AIResponse {
-  response: {
-    result: number;
-  };
-}
+// validationResult の値の取り決め:
+//   0 = 適切（承認済み・ウォール表示）
+//   1 = 不適切（NG・非表示）
+const VALIDATION_OK = 0;
+const VALIDATION_NG = 1;
 
-const validateTanzaku = async (ai: Ai, text: string) => {
-  const result = (await ai.run("@cf/meta/llama-3.3-70b-instruct-fp8-fast", {
+// 検証モデル: Llama 4 Scout（MoE・ネイティブ多言語=日本語対応・131k context）。
+// 旧 llama-3.3-70b は重く応答を支配していたため差し替え。コストも現行よりわずかに低い。
+const MODERATION_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
+
+const validateTanzaku = async (ai: Ai, text: string): Promise<number> => {
+  // Llama 4 系は response_format ではなく guided_json で構造化出力を指定する。
+  const raw = await ai.run(MODERATION_MODEL, {
     prompt: `あなたは校閲のプロフェッショナルです。ユーザーは七夕の短冊プロジェクトにいくつかのメッセージを投稿しています。それらのメッセージを校閲して、明らかに不適切であれば1と、適切であれば0と返してください。\n適切かどうかの基準は、公序良俗に反したことを言っているかどうかです。\n例: {\n  user: "楽しい七夕です!",\n  result: 0\n},{\n  user: "爆発しそうなくらい楽しい",\n  result: 0\n},{\n  user: "A先生キショい",\n  result: 1\n},{\n  user: "蓮舫蓮舫蓮舫蓮舫",\n  result: 1\n},{\n  user: "大学の自治を守ろう",\n  result: 0\n},{\n  user: "美味しいカレーが食べたい",\n  result: 0\n},{\n  user: "中央大学を爆破する",\n  result: 1\n},\nメッセージ: ${text}`,
-    response_format: {
-      type: "json_schema",
-      json_schema: {
-        type: "object",
-        properties: {
-          result: {
-            type: "number",
-            enum: [0, 1]
-          }
+    guided_json: {
+      type: "object",
+      properties: {
+        result: {
+          type: "number",
+          enum: [0, 1]
         }
-      }
+      },
+      required: ["result"]
     }
-  })) as unknown as AIResponse;
+  });
+
+  // Scout は { response: "<JSON文字列>" } を返す。モデルによっては response が
+  // オブジェクトのこともあるため、文字列・オブジェクトの両方を許容して解釈する。
+  const responseField =
+    typeof raw === "object" && raw !== null && "response" in raw
+      ? (raw as { response: unknown }).response
+      : raw;
+
+  let parsed: unknown = responseField;
+  if (typeof responseField === "string") {
+    try {
+      parsed = JSON.parse(responseField);
+    } catch (error) {
+      console.error("JSON Parse Error:", error, responseField);
+      throw new Error("Failed to parse AI response");
+    }
+  }
 
   if (
-    !result ||
-    typeof result !== "object" ||
-    !("response" in result) ||
-    typeof result.response !== "object" ||
-    !("result" in result.response) ||
-    typeof result.response.result !== "number"
+    !parsed ||
+    typeof parsed !== "object" ||
+    !("result" in parsed) ||
+    typeof (parsed as { result: unknown }).result !== "number"
   ) {
-    console.error("Invalid AI Response:", result);
+    console.error("Invalid AI Response:", raw);
     throw new Error("Invalid response from AI");
   }
 
-  try {
-    const parsedResponse = result.response;
-
-    if (![0, 1].includes(parsedResponse.result)) {
-      console.error("Invalid Validation Result:", parsedResponse);
-      throw new Error("Invalid validation result");
-    }
-
-    return parsedResponse.result;
-  } catch (error) {
-    console.error("JSON Parse Error:", error);
-    throw new Error("Failed to parse AI response");
+  const value = (parsed as { result: number }).result;
+  if (value !== VALIDATION_OK && value !== VALIDATION_NG) {
+    console.error("Invalid Validation Result:", parsed);
+    throw new Error("Invalid validation result");
   }
+
+  return value;
 };
 
 export class TanzakuService {

--- a/src/services/tanzaku.service.ts
+++ b/src/services/tanzaku.service.ts
@@ -11,10 +11,66 @@ const VALIDATION_NG = 1;
 // 旧 llama-3.3-70b は重く応答を支配していたため差し替え。コストも現行よりわずかに低い。
 const MODERATION_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
 
+// AI のレスポンス（文字列/オブジェクト混在・前後に余計な文章が付くことがある）から
+// validationResult(0/1) を頑健に取り出す。取り出せなければ null。
+const extractValidationResult = (raw: unknown): number | null => {
+  const responseField =
+    typeof raw === "object" && raw !== null && "response" in raw
+      ? (raw as { response: unknown }).response
+      : raw;
+
+  // すでにオブジェクト（{ result: number }）で返る場合
+  if (
+    responseField &&
+    typeof responseField === "object" &&
+    typeof (responseField as { result?: unknown }).result === "number"
+  ) {
+    const v = (responseField as { result: number }).result;
+    return v === VALIDATION_OK || v === VALIDATION_NG ? v : null;
+  }
+
+  if (typeof responseField !== "string") {
+    return null;
+  }
+
+  // 1) 文字列全体が JSON
+  try {
+    const obj = JSON.parse(responseField) as { result?: unknown };
+    if (obj && typeof obj.result === "number") {
+      return obj.result === VALIDATION_OK || obj.result === VALIDATION_NG
+        ? obj.result
+        : null;
+    }
+  } catch {
+    // フォールバックに進む
+  }
+
+  // 2) 文中に埋め込まれた "result": 0/1 を拾う（前後に説明文があっても可）
+  const match = responseField.match(/result["']?\s*[:=]\s*([01])/i);
+  if (match) {
+    return Number(match[1]);
+  }
+
+  return null;
+};
+
 const validateTanzaku = async (ai: Ai, text: string): Promise<number> => {
-  // Llama 4 系は response_format ではなく guided_json で構造化出力を指定する。
+  // prompt 形式だと few-shot 例文の「続き」を生成してしまい構造化出力が崩れるため、
+  // チャット（messages）形式 + 厳格な system 指示で 1 件だけを判定させる。
   const raw = await ai.run(MODERATION_MODEL, {
-    prompt: `あなたは校閲のプロフェッショナルです。ユーザーは七夕の短冊プロジェクトにいくつかのメッセージを投稿しています。それらのメッセージを校閲して、明らかに不適切であれば1と、適切であれば0と返してください。\n適切かどうかの基準は、公序良俗に反したことを言っているかどうかです。\n例: {\n  user: "楽しい七夕です!",\n  result: 0\n},{\n  user: "爆発しそうなくらい楽しい",\n  result: 0\n},{\n  user: "A先生キショい",\n  result: 1\n},{\n  user: "蓮舫蓮舫蓮舫蓮舫",\n  result: 1\n},{\n  user: "大学の自治を守ろう",\n  result: 0\n},{\n  user: "美味しいカレーが食べたい",\n  result: 0\n},{\n  user: "中央大学を爆破する",\n  result: 1\n},\nメッセージ: ${text}`,
+    messages: [
+      {
+        role: "system",
+        content:
+          "あなたは七夕の短冊メッセージの校閲者です。与えられたメッセージ1件が、公序良俗に反して明らかに不適切なら 1、適切なら 0 と判定します。" +
+          ' 出力は必ず {"result":0} または {"result":1} という JSON オブジェクトだけにし、理由や説明など他のテキストは一切含めないでください。\n' +
+          '判定例:\n「楽しい七夕です!」→ {"result":0}\n「爆発しそうなくらい楽しい」→ {"result":0}\n' +
+          '「A先生キショい」→ {"result":1}\n「蓮舫蓮舫蓮舫蓮舫」→ {"result":1}\n' +
+          '「大学の自治を守ろう」→ {"result":0}\n「美味しいカレーが食べたい」→ {"result":0}\n' +
+          '「中央大学を爆破する」→ {"result":1}'
+      },
+      { role: "user", content: text }
+    ],
     guided_json: {
       type: "object",
       properties: {
@@ -27,39 +83,11 @@ const validateTanzaku = async (ai: Ai, text: string): Promise<number> => {
     }
   });
 
-  // Scout は { response: "<JSON文字列>" } を返す。モデルによっては response が
-  // オブジェクトのこともあるため、文字列・オブジェクトの両方を許容して解釈する。
-  const responseField =
-    typeof raw === "object" && raw !== null && "response" in raw
-      ? (raw as { response: unknown }).response
-      : raw;
-
-  let parsed: unknown = responseField;
-  if (typeof responseField === "string") {
-    try {
-      parsed = JSON.parse(responseField);
-    } catch (error) {
-      console.error("JSON Parse Error:", error, responseField);
-      throw new Error("Failed to parse AI response");
-    }
+  const value = extractValidationResult(raw);
+  if (value === null) {
+    console.error("Could not parse validation result from AI response:", raw);
+    throw new Error("Failed to parse AI response");
   }
-
-  if (
-    !parsed ||
-    typeof parsed !== "object" ||
-    !("result" in parsed) ||
-    typeof (parsed as { result: unknown }).result !== "number"
-  ) {
-    console.error("Invalid AI Response:", raw);
-    throw new Error("Invalid response from AI");
-  }
-
-  const value = (parsed as { result: number }).result;
-  if (value !== VALIDATION_OK && value !== VALIDATION_NG) {
-    console.error("Invalid Validation Result:", parsed);
-    throw new Error("Invalid validation result");
-  }
-
   return value;
 };
 
@@ -79,12 +107,22 @@ export class TanzakuService {
       throw new Error("メッセージは14文字以内で入力してください");
     }
 
-    let validationResult = 0; // デフォルトは適切
+    let validationResult = VALIDATION_OK; // デフォルトは適切
     if (ai) {
-      validationResult = await validateTanzaku(
-        ai,
-        `${data.content}${data.userName}`
-      );
+      try {
+        validationResult = await validateTanzaku(
+          ai,
+          `${data.content}${data.userName}`
+        );
+      } catch (error) {
+        // 検証が失敗しても投稿自体は通す（イベント運用を止めない）。
+        // 失敗時は表示側(0)に倒し、問題があれば管理画面で対応する。
+        console.error(
+          "Validation failed; saving tanzaku as visible (0):",
+          error
+        );
+        validationResult = VALIDATION_OK;
+      }
     }
 
     const activeEvent = await this.prisma.event.findFirst({

--- a/src/services/tanzaku.service.ts
+++ b/src/services/tanzaku.service.ts
@@ -49,9 +49,7 @@ const extractValidationResult = (raw: unknown): number | null => {
   //    モデルが暴走して複数の result を羅列することがあるため、全件を集めて
   //    値が一意のときだけ採用する。0 と 1 が混在＝曖昧なら null を返して
   //    安全側（呼び出し元で非表示=1）に倒す。最初の一致を盲信しない。
-  const matches = [
-    ...responseField.matchAll(/result["']?\s*[:=]\s*([01])/gi)
-  ];
+  const matches = [...responseField.matchAll(/result["']?\s*[:=]\s*([01])/gi)];
   const distinct = new Set(matches.map((m) => Number(m[1])));
   if (distinct.size === 1) {
     return [...distinct][0];


### PR DESCRIPTION
## 背景 / 調査結果

`POST /tanzaku` の投稿遅延（毎回10〜80秒）を調査。Cloudflare Workers Observability の本番ログ実測で **AI 検証がボトルネックであることを定量的に確定**した（POST: 壁時間 中央値10.5秒/p99 69秒・CPU 平均28ms ＝ 99.9% が外部await待ち。GET は~100msで正常）。

## このPRのスコープ

「検証モデルの差し替え（③）」が主目的。**`createTanzaku` の同期実行構造は維持**（根本対処の非同期化=① は別対応）。ただしデプロイ時に発覚した不具合修正に伴い、**AI検証失敗時のエラーハンドリング仕様も意図的に変更**している（下記「挙動の変更」参照）。

## 変更内容

`src/services/tanzaku.service.ts`:

- **検証モデル差し替え**: `@cf/meta/llama-3.3-70b-instruct-fp8-fast`（70B 密）→ `@cf/meta/llama-4-scout-17b-16e-instruct`（Llama 4 Scout, 17Bアクティブ MoE・日本語対応・131k context）。本番実測 約1.2〜2.0秒（70Bの10〜69秒から大幅改善）。
- **`messages`（チャット）形式 + 厳格な system 指示** に変更。`prompt` 形式だと few-shot 例文を「続き」生成して構造化出力が崩れ全件500になったため（経緯は下記）。Llama 4 は `response_format` 非対応で `guided_json` を使用。
- **`extractValidationResult()` による堅牢パース**: オブジェクト / JSON文字列 / 文中の `"result":N` のいずれからも 0/1 を抽出。複数の result が混在する場合は曖昧として失敗扱い（安全側）。

## 挙動の変更（仕様・意図的）

⚠️ 元は AI 検証失敗時に例外送出 → POST が 500。本PRでは:

- **検証失敗を非致命化**: `validateTanzaku` を try/catch し、**失敗しても投稿は 200 で通す**（イベント運用を検証エラーで止めない）。
- **失敗時は安全側=非表示(1)で保存**: 未検証コンテンツを公開ウォールに出さない。正当な投稿が巻き込まれた場合は `/manage` で表示(0)に修正可能。
- 名前(`userName`)側のNGも検出対象（`content + userName` を連結してAIに渡すため）。

## コスト

| モデル | 入力 | 出力 |
|---|---|---|
| 現行 70B | \$0.293/M | \$2.253/M |
| Scout | \$0.27/M | \$0.85/M |

入力多め・出力極小の用途では実質同額〜わずかに低い。**コスト増なし。**

## デプロイ時に起きた500（記録）

デプロイ直後に全POSTが500（`Failed to parse AI response`）。原因はScoutが`prompt`形式のfew-shotを「続き」として自由文生成し（出力に role トークン`assistant`混入）、`guided_json`が効かず`JSON.parse`失敗。→ 上記の `messages`化＋堅牢パース＋非致命化で解決。本番でNG→1/OK→0、200・約1.4秒を確認済み。

## スコープ外（今後）

- **検証の非同期化（pending即保存 + `waitUntil`）は本PRに含めない。** これを入れて初めてPOSTがサブ秒で即レスになる（Scout化で約1.4秒まで短縮済みだが同期待ち構造は残存）。

## 動作確認

- [x] 本番デプロイ・OK→0/NG→1（名前側NG含む）を実機確認
- [ ] マージ後、必要なら GitHub Actions 経由の正規デプロイで再反映
- [ ] 動作確認用テスト短冊の削除（`/manage`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)