### PR TITLE
ci: actions/checkout・setup-node を v5 へ更新 (Node.js 20 非推奨対応)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
       - uses: pnpm/action-setup@v4
@@ -25,8 +25,8 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
       - uses: pnpm/action-setup@v4
@@ -38,7 +38,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 10
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "pnpm"
@@ -58,13 +58,13 @@ jobs:
     name: D1 Deploy
     if: ${{ github.event.inputs.with_d1 == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 10
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "pnpm"
@@ -85,7 +85,7 @@ jobs:
       release_tag: ${{ steps.release_tag.outputs.VERSION }}
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Generate release tag
         id: release_tag


### PR DESCRIPTION
## 概要
リリース実行時に出ていた以下の警告への対応です。

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4.
> https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Node 20 を宣言している GitHub 製アクションを、Node 24 対応の v5 へ更新しました。

## 変更
- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5`
- 対象: `.github/workflows/ci.yaml` / `.github/workflows/deploy.yaml`

## 据え置き
- `pnpm/action-setup@v4` — Node20 宣言の非推奨対象ではなく、最新も v4
- `cloudflare/wrangler-action@v3` — 警告対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)