### PR TITLE
ci: wrangler-action/pnpm-action-setup を node24 ランタイム版へ更新

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
       - run: pnpm install
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
       - run: pnpm install

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
       - name: Use Node.js 22
@@ -33,7 +33,7 @@ jobs:
         run: pnpm install
 
       - name: Deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
       - name: Use Node.js 22
@@ -72,7 +72,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - uses: cloudflare/wrangler-action@v3
+      - uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## 概要
デプロイ/CI実行時に残っていた **Node.js 20 非推奨警告** を解消します。

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: cloudflare/wrangler-action@v3, pnpm/action-setup@v4

## 原因
#9 で `actions/checkout`・`actions/setup-node` を v5 に更新しましたが、警告の対象は別のサードパーティ製アクションでした。`cloudflare/wrangler-action@v3` と `pnpm/action-setup@v4` は `action.yml` で `using: node20` を宣言しているため、ランナーが node24 へ強制実行しつつ非推奨警告を出していました。これは `setup-node` のバージョンでは解消できません。

## 変更点
- `pnpm/action-setup`: `v4` → `v6`（`using: node24`）
- `cloudflare/wrangler-action`: `v3` → `v4`（`using: node24`）
- 対象: `.github/workflows/ci.yaml`, `.github/workflows/deploy.yaml`

## 互換性
使用中の入力はすべて新バージョンで維持されています。
- pnpm/action-setup v6: `version`
- wrangler-action v4: `apiToken`, `accountId`, `secrets`, `command`

🤖 Generated with [Claude Code](https://claude.com/claude-code)